### PR TITLE
Add OCaml files to Makefile.coq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ endif
 
 MLFILES = extraction/chord/coq/ExtractedChord.ml extraction/chord/coq/ExtractedChord.mli \
 	extraction/chord/coq/ExtractedChordShed.ml extraction/chord/coq/ExtractedChordShed.mli
-MLFILES_DEPS = 'extraction/chord/coq/ExtractChord.v systems/Chord.vo shed/ChordShed.vo'
-MLFILES_COMMAND = '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/chord/coq/ExtractChord.v'
 
 default: Makefile.coq
 	$(MAKE) -f Makefile.coq
@@ -29,7 +27,9 @@ quick: Makefile.coq
 
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq \
-	  -extra 'extraction/chord/coq/ExtractedChord.ml extraction/chord/coq/ExtractedChord.mli extraction/chord/coq/ExtractedChordShed.ml extraction/chord/coq/ExtractedChordShed.mli' $(MLFILES_DEPS) $(MLFILES_COMMAND)
+	  -extra '$(MLFILES)' \
+	    'extraction/chord/coq/ExtractChord.v systems/Chord.vo shed/ChordShed.vo' \
+	    '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/chord/coq/ExtractChord.v'
 
 clean:
 	if [ -f Makefile.coq ]; then \

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ $(info $(CHECKPATH))
 $(warning checkpath reported an error)
 endif
 
+MLFILES = extraction/chord/coq/ExtractedChord.ml extraction/chord/coq/ExtractedChord.mli \
+	extraction/chord/coq/ExtractedChordShed.ml extraction/chord/coq/ExtractedChordShed.mli
+MLFILES_DEPS = 'extraction/chord/coq/ExtractChord.v systems/Chord.vo shed/ChordShed.vo'
+MLFILES_COMMAND = '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/chord/coq/ExtractChord.v'
+
 default: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
@@ -23,16 +28,22 @@ quick: Makefile.coq
 	$(MAKE) -f Makefile.coq quick
 
 Makefile.coq: _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq
+	coq_makefile -f _CoqProject -o Makefile.coq \
+	  -extra 'extraction/chord/coq/ExtractedChord.ml' $(MLFILES_DEPS) $(MLFILES_COMMAND) \
+	  -extra 'extraction/chord/coq/ExtractedChord.mli' $(MLFILES_DEPS) $(MLFILES_COMMAND) \
+	  -extra 'extraction/chord/coq/ExtractedChordShed.ml' $(MLFILES_DEPS) $(MLFILES_COMMAND) \
+	  -extra 'extraction/chord/coq/ExtractedChordShed.mli' $(MLFILES_DEPS) $(MLFILES_COMMAND)
 
 clean:
 	if [ -f Makefile.coq ]; then \
 	  $(MAKE) -f Makefile.coq cleanall; fi
 	rm -f Makefile.coq
 
-chord: Makefile.coq
-	$(MAKE) -f Makefile.coq extraction/chord/coq/ExtractChord.vo
+chord: Makefile.coq $(MLFILES)
 	$(MAKE) -C extraction/chord
+
+$(MLFILES): Makefile.coq
+	$(MAKE) -f Makefile.coq $@
 
 lint:
 	@echo "Possible use of hypothesis names:"

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,7 @@ quick: Makefile.coq
 
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq \
-	  -extra 'extraction/chord/coq/ExtractedChord.ml' $(MLFILES_DEPS) $(MLFILES_COMMAND) \
-	  -extra 'extraction/chord/coq/ExtractedChord.mli' $(MLFILES_DEPS) $(MLFILES_COMMAND) \
-	  -extra 'extraction/chord/coq/ExtractedChordShed.ml' $(MLFILES_DEPS) $(MLFILES_COMMAND) \
-	  -extra 'extraction/chord/coq/ExtractedChordShed.mli' $(MLFILES_DEPS) $(MLFILES_COMMAND)
+	  -extra 'extraction/chord/coq/ExtractedChord.ml extraction/chord/coq/ExtractedChord.mli extraction/chord/coq/ExtractedChordShed.ml extraction/chord/coq/ExtractedChordShed.mli' $(MLFILES_DEPS) $(MLFILES_COMMAND)
 
 clean:
 	if [ -f Makefile.coq ]; then \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean:
 	  $(MAKE) -f Makefile.coq cleanall; fi
 	rm -f Makefile.coq
 
-chord: Makefile.coq $(MLFILES)
+chord: $(MLFILES)
 	$(MAKE) -C extraction/chord
 
 $(MLFILES): Makefile.coq

--- a/extraction/chord/Makefile
+++ b/extraction/chord/Makefile
@@ -1,12 +1,12 @@
 OCAMLBUILD = ocamlbuild -lib str -lib unix -I lib -I ml -I coq
 
+MLFILES = coq/ExtractedChord.ml coq/ExtractedChord.mli \
+	coq/ExtractedChordShed.ml coq/ExtractedChordShed.mli
+
 default: chord.native client.native chordshed.native
 
-coq/ExtractedChord.ml:
-	make -C ../.. extraction/chord/coq/ExtractedChord.ml
-
-coq/ExtractedChordShed.ml:
-	make -C ../.. extraction/chord/coq/ExtractedChordShed.ml
+$(MLFILES):
+	make -C ../.. extraction/chord/$@
 
 chord.native: coq/ExtractedChord.ml ml/*.ml lib/*.ml
 	$(OCAMLBUILD) chord.native
@@ -20,4 +20,6 @@ chordshed.native: coq/ExtractedChordShed.ml ml/*.ml lib/*.ml
 clean:
 	$(OCAMLBUILD) chord.native -clean
 
-.PHONY : default clean
+.PHONY : default clean $(MLFILES)
+
+.NOTPARALLEL: chord.native client.native chordshed.native

--- a/extraction/chord/Makefile
+++ b/extraction/chord/Makefile
@@ -3,12 +3,10 @@ OCAMLBUILD = ocamlbuild -lib str -lib unix -I lib -I ml -I coq
 default: chord.native client.native chordshed.native
 
 coq/ExtractedChord.ml:
-	# there has to be a -B flag here becuase there's no way to explicitly
-	# ask a Makefile.coq for extraction targets
-	make -B -C ../../ -f Makefile.coq extraction/chord/coq/ExtractChord.vo
+	make -C ../.. extraction/chord/coq/ExtractedChord.ml
 
 coq/ExtractedChordShed.ml:
-	make -B -C ../../ -f Makefile.coq extraction/chord/coq/ExtractChord.vo
+	make -C ../.. extraction/chord/coq/ExtractedChordShed.ml
 
 chord.native: coq/ExtractedChord.ml ml/*.ml lib/*.ml
 	$(OCAMLBUILD) chord.native


### PR DESCRIPTION
To easier build and clean OCaml files, add them to Makefile.coq using -extra option.