### PR TITLE
extracted files PHONY in main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,4 @@ lint:
 distclean: clean
 	rm -f _CoqProject
 
-.PHONY: default quick clean lint distclean chord
+.PHONY: default quick clean lint distclean chord $(MLFILES)


### PR DESCRIPTION
Yet another makefile quality-of-life fix. This should allow rebuilding extracted files whenever any files they depend on are changed.