### PR TITLE
use local OPAM files in Travis jobs

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -7,19 +7,12 @@ opam repo add coq-released https://coq.inria.fr/opam/released
 opam repo add distributedcomponents-dev http://opam-dev.distributedcomponents.net
 
 opam pin add coq $COQ_VERSION --yes --verbose
-opam pin add coq-mathcomp-ssreflect $SSREFLECT_VERSION --yes --verbose
-opam install StructTact InfSeqExt verdi --yes --verbose
 
 case $MODE in
   chord)
-    opam install verdi-runtime --yes --verbose
-    ./build.sh chord
-    ;;
-  chordshed)
-    opam install verdi-runtime --yes --verbose
-    ./build.sh chordshed
+    opam pin add chord . --yes --verbose
     ;;
   *)
-    ./build.sh
+    opam pin add verdi-chord . --yes --verbose
     ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
 env:
   global:
     - COQ_VERSION=8.5.3
-    - SSREFLECT_VERSION=1.6
   matrix:
   - MODE=build
   - MODE=chord

--- a/chord.install
+++ b/chord.install
@@ -1,0 +1,2 @@
+bin: [ "extraction/chord/_build/ml/chord.native" {"chord-server"}
+       "extraction/chord/_build/ml/client.native" {"chord-client"} ]

--- a/chord.opam
+++ b/chord.opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "chord"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/DistributedComponents/verdi-chord"
+dev-repo: "https://github.com/DistributedComponents/verdi-chord.git"
+bug-reports: "https://github.com/DistributedComponents/verdi-chord/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" "chord" ]
+]
+available: [ ocaml-version >= "4.02.3" ]
+depends: [
+  "coq" {>= "8.5" & < "8.6~"}
+  "verdi" {= "dev"}
+  "StructTact" {= "dev"}
+  "InfSeqExt" {= "dev"}
+  "verdi-runtime" {= "dev"}
+  "ocamlbuild" {build}
+]
+
+authors: [
+  "Ryan Doenges <>"
+]

--- a/verdi-chord.opam
+++ b/verdi-chord.opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+name: "verdi-chord"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/DistributedComponents/verdi-chord"
+dev-repo: "https://github.com/DistributedComponents/verdi-chord.git"
+bug-reports: "https://github.com/DistributedComponents/verdi-chord/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+depends: [
+  "coq" {>= "8.5" & < "8.6~"}
+  "verdi" {= "dev"}
+  "StructTact" {= "dev"}
+  "InfSeqExt" {= "dev"}
+]
+
+authors: [
+  "Ryan Doenges <>"
+]


### PR DESCRIPTION
Switch to using declared dependencies for Travis, rather than operationally defined ones in the Travis script.