### PR TITLE
Coq 8.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _CoqProject
 _CoqProject.tmp
 Makefile.coq
 Makefile.coq.bak
+Makefile.coq.conf
 *~
 .coq-native/
 *.aux

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - gnuplot
 env:
   global:
-    - COQ_VERSION=8.6.1
+    - COQ_VERSION=8.7.0
   matrix:
   - MODE=build
   - MODE=chord

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ $(info $(CHECKPATH))
 $(warning checkpath reported an error)
 endif
 
-CHORDMLFILES = extraction/chord/coq/ExtractedChord.ml extraction/chord/coq/ExtractedChord.mli
-MLFILES = $(CHORDMLFILES)
+MLFILES = extraction/chord/coq/ExtractedChord.ml extraction/chord/coq/ExtractedChord.mli
 
 default: Makefile.coq
 	$(MAKE) -f Makefile.coq
@@ -38,11 +37,9 @@ proofalytics-aux: Makefile.coq
 
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq -install none \
-	  -extra '$(CHORDMLFILES)' \
+	  -extra '$(MLFILES)' \
 	    'extraction/chord/coq/ExtractChord.v systems/chord/Chord.vo' \
-	    '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/chord/coq/ExtractChord.v' \
-	  -extra-phony 'distclean' 'clean' \
-	    'rm -f $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.aux,$$(VFILES)))))'
+	    '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/chord/coq/ExtractChord.v'
 
 clean:
 	if [ -f Makefile.coq ]; then \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Verdi framework](http://verdi.uwplse.org/).
 Requirements
 ------------
 
- - [`Coq 8.6`](https://coq.inria.fr/coq-86)
+ - [`Coq 8.6.1`](https://coq.inria.fr/coq-86) or [`Coq 8.7`](https://coq.inria.fr/coq-87)
  - [`Mathematical Components 1.6`](http://math-comp.github.io/math-comp/) (`ssreflect`)
  - [`Verdi`](https://github.com/uwplse/verdi)
  - [`StructTact`](https://github.com/uwplse/StructTact)

--- a/chord.opam
+++ b/chord.opam
@@ -14,7 +14,7 @@ build: [
 ]
 available: [ ocaml-version >= "4.02.3" ]
 depends: [
-  "coq" {>= "8.6" & < "8.7~"}
+  "coq" {((>= "8.6.1" & < "8.7~") | (>= "8.7" & < "8.8~"))}
   "coq-mathcomp-ssreflect" {>= "1.6" & < "1.7~"}
   "verdi" {= "dev"}
   "StructTact" {= "dev"}
@@ -25,4 +25,8 @@ depends: [
 
 authors: [
   "Ryan Doenges <>"
+  "Doug Woos <>"
+  "Karl Palmskog <>"
+  "Zachary Tatlock <>"
+  "James Wilcox <>"
 ]

--- a/configure
+++ b/configure
@@ -11,6 +11,7 @@ NAMESPACE_lib="Chord"
 NAMESPACE_systems_chord_util="Chord"
 NAMESPACE_systems_chord_props="Chord"
 NAMESPACE_systems_chord="Chord"
+NAMESPACE_extraction_chord_coq="Chord"
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi" "InfSeqExt.infseq" "Build InfSeqExt before building Verdi")
 Verdi_DIRS=(core lib systems extraction)
 source script/coqproject.sh

--- a/script/coqproject.sh
+++ b/script/coqproject.sh
@@ -69,7 +69,7 @@ for dir in ${DIRS[@]}; do
     namespace_var=${namespace_var//\//_}
     namespace_var=${namespace_var//-/_}
     namespace_var=${namespace_var//./_}
-    namespace=${!namespace_var:="\"\""}
+    namespace=${!namespace_var:="''"}
     LINE="-Q $dir $namespace"
     echo $LINE >> $COQPROJECT_TMP
 done

--- a/verdi-chord.opam
+++ b/verdi-chord.opam
@@ -13,7 +13,7 @@ build: [
   [ make "-j%{jobs}%" ]
 ]
 depends: [
-  "coq" {>= "8.6" & < "8.7~"}
+  "coq" {((>= "8.6.1" & < "8.7~") | (>= "8.7" & < "8.8~"))}
   "coq-mathcomp-ssreflect" {>= "1.6" & < "1.7~"}
   "verdi" {= "dev"}
   "StructTact" {= "dev"}
@@ -24,4 +24,6 @@ authors: [
   "Ryan Doenges <>"
   "Karl Palmskog <>"
   "Doug Woos <>"
+  "Zachary Tatlock <>"
+  "James Wilcox <>"
 ]


### PR DESCRIPTION
Last few configuration changes for Coq 8.7 compatibility. Still works with 8.6.1, but note that Travis will only use 8.7.0 if this is merged.

@hackedy can you check that proofalytics looks as expected?