### PR TITLE
Change to correct_succs

### DIFF
--- a/systems/chord-props/WfPtrSuccListInvariant.v
+++ b/systems/chord-props/WfPtrSuccListInvariant.v
@@ -1,17 +1,20 @@
 Require Import List.
 Import ListNotations.
 
+Require Import StructTact.StructTactics.
+Require Import StructTact.ListTactics.
+
 Require Import Chord.Chord.
 
 Require Import Chord.SystemLemmas.
 Require Import Chord.SystemReachable.
 Require Import Chord.SystemPointers.
 
-Lemma wf_ptr_succ_list_invariant :
-  forall gst h st p rest,
+Lemma wf_ptr_succ_list_invariant' :
+  forall gst h st p,
     reachable_st gst ->
     sigma gst h = Some st ->
-    succ_list st = p :: rest ->
+    In p (succ_list st) ->
     wf_ptr p.
 Proof.
 (*
@@ -23,3 +26,15 @@ DIFFICULTY: 3
 USED: In phase one.
 *)
 Admitted.
+
+
+Lemma wf_ptr_succ_list_invariant :
+  forall gst h st p rest,
+    reachable_st gst ->
+    sigma gst h = Some st ->
+    succ_list st = p :: rest ->
+    wf_ptr p.
+Proof.
+  intros.
+  eapply wf_ptr_succ_list_invariant'; eauto. find_rewrite. in_crush.
+Qed.


### PR DESCRIPTION
I was able to prove `phase_three_error_sound` by changing `correct_succs`. I'm pretty sure it's not provable otherwise, but I thought you should review the change since AFAICT `correct_succs` is trusted.